### PR TITLE
Feature - Default to output 1080p60, or last used output, on device boot when no input signal detected.

### DIFF
--- a/gbs-control/gbs-control.ino
+++ b/gbs-control/gbs-control.ino
@@ -1274,6 +1274,15 @@ void setAndUpdateSogLevel(uint8_t level)
 // Function should not further nest, so it can be called in syncwatcher
 void goLowPowerWithInputDetection()
 {
+    if (rto->noSignalBlackScreenMode) {
+        // Keep DAC and sync output active so the TV stays locked and the OSD remains usable.
+        // Just re-arm the sync processor to keep scanning for a real input signal.
+        prepareSyncProcessor();
+        rto->isInLowPowerMode = true;
+        SerialM.println(F("No signal: maintaining black screen output, scanning inputs..."));
+        LEDOFF;
+        return;
+    }
     GBS::OUT_SYNC_CNTRL::write(0); // no H / V sync out to PAD
     GBS::DAC_RGBS_PWDNZ::write(0); // direct disableDAC()
     //zeroAll();
@@ -1730,6 +1739,7 @@ uint8_t inputAndSyncDetect()
         }
         return 0;
     } else if (syncFound == 1 && isInfoDisplayActive == 0) { // input is RGBS
+        rto->noSignalBlackScreenMode = false; // real signal found, exit black screen mode
         rto->inputIsYpBpR = 0;
         rto->sourceDisconnected = false;
         rto->isInLowPowerMode = false;
@@ -1738,6 +1748,7 @@ uint8_t inputAndSyncDetect()
         LEDON;
         return 1;
     } else if (syncFound == 2 && isInfoDisplayActive == 0) {
+        rto->noSignalBlackScreenMode = false; // real signal found, exit black screen mode
         rto->inputIsYpBpR = 1;
         rto->sourceDisconnected = false;
         rto->isInLowPowerMode = false;
@@ -1746,6 +1757,7 @@ uint8_t inputAndSyncDetect()
         LEDON;
         return 2;
     } else if (syncFound == 3 && isInfoDisplayActive == 0) { // input is RGBHV
+        rto->noSignalBlackScreenMode = false; // real signal found, exit black screen mode
         //already applied
         rto->isInLowPowerMode = false;
         rto->inputIsYpBpR = 0;
@@ -3409,7 +3421,9 @@ void doPostPresetLoadSteps()
     rto->scanlinesEnabled = false;
     rto->failRetryAttempts = 0;
     rto->videoIsFrozen = true;       // ensures unfreeze
-    rto->sourceDisconnected = false; // this must be true if we reached here (no syncwatcher operation)
+    if (!rto->noSignalBlackScreenMode) {
+        rto->sourceDisconnected = false; // this must be true if we reached here (no syncwatcher operation)
+    }
     rto->boardHasPower = true;       //same
 
     if (rto->presetID == 0x06 || rto->presetID == 0x16) {
@@ -3986,7 +4000,7 @@ void doPostPresetLoadSteps()
         rto->videoStandardInput = 14;
     }
 
-    if (GBS::GBS_OPTION_SCALING_RGBHV::read() == 0) {
+    if (GBS::GBS_OPTION_SCALING_RGBHV::read() == 0 && !rto->noSignalBlackScreenMode) {
         unsigned long timeout = millis();
         while ((!getStatus16SpHsStable()) && (millis() - timeout < 2002)) {
             delay(4);
@@ -4389,6 +4403,15 @@ void applyPresets(uint8_t result)
     if (!rto->boardHasPower) {
         SerialM.println(F("GBS board not responding!"));
         return;
+    }
+
+    // When a real input is detected and processed, persist its video standard so the
+    // device can output a stable black screen on the next boot if no signal is present.
+    if (result > 0 && result <= 9 && !rto->noSignalBlackScreenMode) {
+        if (uopt->lastVideoStandard != result) {
+            uopt->lastVideoStandard = result;
+            saveUserPrefs();
+        }
     }
 
     // if RGBHV scaling and invoked through web ui or custom preset
@@ -7537,6 +7560,7 @@ void loadDefaultUserOptions()
     uopt->advFilterCombPAL = ADV_FILTER_COMB_PAL_DEFAULT;
     // HDMI Limited Range
     uopt->hdmiLimitedRange = 1;
+    uopt->lastVideoStandard = 0;
 }
 
 //RF_PRE_INIT() {
@@ -7760,6 +7784,7 @@ void setup()
     rto->continousStableCounter = 0;
     rto->currentLevelSOG = 5;
     rto->thisSourceMaxLevelSOG = 31; // 31 = auto sog has not (yet) run
+    rto->noSignalBlackScreenMode = false;
 
     adco->r_gain = 0;
     adco->g_gain = 0;
@@ -7993,6 +8018,9 @@ void setup()
             uopt->advHue = (uint8_t)((f.read() - '0') * 100 + (f.read() - '0') * 10 + (f.read() - '0'));
             if (uopt->advHue > 254) uopt->advHue = 128;
 
+            uopt->lastVideoStandard = (uint8_t)(f.read() - '0');
+            if (uopt->lastVideoStandard > 9) uopt->lastVideoStandard = 0;
+
             f.close();
         }
     }
@@ -8103,6 +8131,18 @@ void setup()
         // Load slot settings into memory (ADV, GBS colors, etc.)
         // These will be applied by doPostPresetLoadSteps() when syncWatcher calls applyPresets()
         loadSlotSettings();
+
+        // If we have a last known video standard and bypass mode is not preferred, apply that
+        // preset now so the TV receives a stable sync and the OSD remains accessible while the
+        // device scans for an input signal.  doPostPresetLoadSteps() skips its SP wait loops and
+        // does not clear sourceDisconnected in this mode, so the 500ms polling loop stays active.
+        if (uopt->lastVideoStandard > 0 && uopt->presetPreference != OutputBypass) {
+            rto->noSignalBlackScreenMode = true;
+            rto->videoStandardInput = uopt->lastVideoStandard; // lets menu handlers use correct standard
+            SerialM.println(F("No input signal: enabling black screen output"));
+            applyPresets(uopt->lastVideoStandard);
+            // sourceDisconnected remains true; input polling loop will keep scanning
+        }
 
         delay(4); // help wifi (presets are unloaded now)
         handleWiFi(1);
@@ -11381,6 +11421,7 @@ void saveUserPrefs()
     f.write(uopt->advHue / 100 + '0');
     f.write((uopt->advHue / 10) % 10 + '0');
     f.write(uopt->advHue % 10 + '0');
+    f.write(uopt->lastVideoStandard + '0');
     f.close();
 }
 

--- a/gbs-control/gbs-control.ino
+++ b/gbs-control/gbs-control.ino
@@ -8132,15 +8132,21 @@ void setup()
         // These will be applied by doPostPresetLoadSteps() when syncWatcher calls applyPresets()
         loadSlotSettings();
 
-        // If we have a last known video standard and bypass mode is not preferred, apply that
-        // preset now so the TV receives a stable sync and the OSD remains accessible while the
-        // device scans for an input signal.  doPostPresetLoadSteps() skips its SP wait loops and
-        // does not clear sourceDisconnected in this mode, so the 500ms polling loop stays active.
-        if (uopt->lastVideoStandard > 0 && uopt->presetPreference != OutputBypass) {
+        // Always output a stable signal when there is no input, so the TV stays locked and the
+        // OSD is accessible via the remote.  If a previous session was detected, replicate its
+        // exact format; otherwise fall back to a 1080p60 black screen (NTSC standard + Output1080P).
+        if (uopt->presetPreference != OutputBypass) {
             rto->noSignalBlackScreenMode = true;
-            rto->videoStandardInput = uopt->lastVideoStandard; // lets menu handlers use correct standard
+            uint8_t noSignalStandard = (uopt->lastVideoStandard > 0) ? uopt->lastVideoStandard : 1;
+            rto->videoStandardInput = noSignalStandard; // lets menu handlers use correct standard
+            // On first boot (no prior session) temporarily override preference to 1080p60
+            PresetPreference savedPreference = uopt->presetPreference;
+            if (uopt->lastVideoStandard == 0) {
+                uopt->presetPreference = Output1080P;
+            }
             SerialM.println(F("No input signal: enabling black screen output"));
-            applyPresets(uopt->lastVideoStandard);
+            applyPresets(noSignalStandard);
+            uopt->presetPreference = savedPreference; // restore user preference after preset is applied
             // sourceDisconnected remains true; input polling loop will keep scanning
         }
 

--- a/gbs-control/options.h
+++ b/gbs-control/options.h
@@ -90,6 +90,7 @@ struct runTimeOptions
     bool isValidForScalingRGBHV;
     bool useHdmiSyncFix;
     bool extClockGenDetected;
+    bool noSignalBlackScreenMode; // true when outputting black screen at boot with no input
 };
 // remember adc options across presets
 struct adcOptions

--- a/gbs-control/pro/gbs-control-pro.cpp
+++ b/gbs-control/pro/gbs-control-pro.cpp
@@ -517,8 +517,8 @@ void readYUVtoRGBConversion(void)
 void applyVideoModePreset(void)
 {
     uint8_t videoMode = getVideoMode();
-    if (videoMode == 0 && GBS::STATUS_SYNC_PROC_HSACT::read()) {
-        videoMode = rto->videoStandardInput;
+    if (videoMode == 0 && (GBS::STATUS_SYNC_PROC_HSACT::read() || rto->noSignalBlackScreenMode)) {
+        videoMode = rto->videoStandardInput; // in no-signal mode this is lastVideoStandard
     }
     if (uopt->presetPreference != 2) {
         rto->useHdmiSyncFix = 1;

--- a/gbs-control/pro/menu/menu-core.cpp
+++ b/gbs-control/pro/menu/menu-core.cpp
@@ -252,8 +252,10 @@ static void IR_handleMenuKeyPress(void)
     lastMenuItemTime = millis();
     NEW_OLED_MENU = false;
 
-    // Check if source is disconnected or board has no power
-    bool noSignal = rto->sourceDisconnected ||
+    // Check if source is disconnected or board has no power.
+    // noSignalBlackScreenMode means we intentionally have output active with no real input,
+    // so treat it like a connected source to give access to the full menu.
+    bool noSignal = (rto->sourceDisconnected && !rto->noSignalBlackScreenMode) ||
                     !rto->boardHasPower ||
                     GBS::PAD_CKIN_ENZ::read();
 

--- a/gbs-control/pro/options-pro.h
+++ b/gbs-control/pro/options-pro.h
@@ -109,6 +109,8 @@ enum TVMODE_PresetPreference : uint8_t {
     uint8_t advCombChromaModePAL;   /* PAL Chroma Mode (0=Adaptive, 4=Off, 5-7=Fixed) */ \
     uint8_t advCombChromaTapsPAL;   /* PAL Chroma Taps (0-3, default 3=5→4 lines) */ \
     /* HDMI Limited Range */ \
-    uint8_t hdmiLimitedRange;       /* Force Limited Range output (0=Off, 1=HD, 2=SD, 3=All) */
+    uint8_t hdmiLimitedRange;       /* Force Limited Range output (0=Off, 1=HD, 2=SD, 3=All) */ \
+    /* No-signal black screen */ \
+    uint8_t lastVideoStandard;      /* Last successfully detected video standard (0=none, 1-9) */
 
 #endif // OPTIONS_PRO_H_


### PR DESCRIPTION
When the device is booted with no previous session found, it will output a 1080p60 signal to the display device, which allows OSD menu access. This fixes the inconsistent previous behaviour where it would output a 720x480 signal after pressing the remote buttons a few times.

Specifically addresses issue/feature request #25 

This branch is based on the Brisma main branch, rather than 2.3.0.